### PR TITLE
Support nonum, nodisp, notoc in header

### DIFF
--- a/review.lua
+++ b/review.lua
@@ -177,14 +177,15 @@ function Header(level, s, attr)
     classes[cls] = true
   end
 
-  headmark = string.format("%s[%s]", headmark,
+  headmark = headmark .. (
     -- Re:view's behavior
-    classes["column"] and "column" or (
-    classes["nonum"] and "nonum" or (
-    classes["nodisp"] and "nodisp" or (
-    classes["notoc"] and "notoc" or (
+    classes["column"] and "[column]" or (
+    classes["nonum"] and "[nonum]" or (
+    classes["nodisp"] and "[nodisp]" or (
+    classes["notoc"] and "[notoc]" or (
     -- Pandoc's behavior
-    classes["unnumbered"] and (classes["unlisted"] and "notoc" or "nonum") or (
+    classes["unnumbered"] and (
+      classes["unlisted"] and "[notoc]" or "[nonum]") or (
     -- None
     "")))))
   )

--- a/review.lua
+++ b/review.lua
@@ -167,18 +167,27 @@ local function attr_val(attr, key)
 end
 
 function Header(level, s, attr)
-  headmark = ""
+  local headmark = ""
   for i = 1, level do
     headmark = headmark .. "="
   end
 
-  cls = attr_val(attr, "class")
-  if (cls ~= "") then
-    if (cls == "unnumbered") then
-      cls = "nonum"
-    end
-    headmark = headmark .. "[" .. cls .. "]"
+  local classes = {}
+  for cls in attr_val(attr, "class"):gmatch("[^%s]+") do
+    classes[cls] = true
   end
+
+  headmark = string.format("%s[%s]", headmark,
+    -- Re:view's behavior
+    classes["column"] and "column" or (
+    classes["nonum"] and "nonum" or (
+    classes["nodisp"] and "nodisp" or (
+    classes["notoc"] and "notoc" or (
+    -- Pandoc's behavior
+    classes["unnumbered"] and (classes["unlisted"] and "notoc" or "nonum") or (
+    -- None
+    "")))))
+  )
 
   if (config.use_header_id and attr.id ~= "" and attr.id ~= s) then
     headmark = headmark .. "{" .. attr.id .. "}"


### PR DESCRIPTION
こんな感じで一通りのヘッダーオプションに対応しました。

```bash
pandoc -t review.lua <<< "# foo {.column}"
# =[column] foo
pandoc -t review.lua <<< "# foo {.nonum}"
# =[nonum] foo
pandoc -t review.lua <<< "# foo {.nodisp}"
# =[nodisp] foo
pandoc -t review.lua <<< "# foo {.notoc}"
# =[notoc] foo
pandoc -t review.lua <<< "# foo {.unnumbered}"
# =[nonum] foo
pandoc -t review.lua <<< "# foo {.unnumbered .unlisted}"
# =[notoc] foo
```