### PR TITLE
improve CodeBlock and fix #16

### DIFF
--- a/review.lua
+++ b/review.lua
@@ -256,19 +256,9 @@ function BlockQuote(s)
 end
 
 function CodeBlock(s, attr)
-  local caption = attr_val(attr, "caption") -- ```{caption=CAPTION}
-  local identifier = ""
-  local em = ""
-  if (caption ~= "") then
-    list_num = list_num + 1
-    identifier = "[list" .. list_num .. "]"
-  else
-    em = "em"
-  end
-
   local classes = attr_classes(attr)
   local lang = ""
-  local not_lang = {numberLines = true, num = true}
+  local not_lang = {numberLines = true, num = true, em = true}
   not_lang["number-lines"] = true
   for key,_ in pairs(classes) do
     if not_lang[key] ~= true then
@@ -285,10 +275,20 @@ function CodeBlock(s, attr)
     for _, key in ipairs({"startFrom", "start-from", "firstlinenum"}) do
       firstlinenum = attr_val(attr, key)
       if firstlinenum ~= "" then
-        tag = "//firstlinenum[" .. firstlinenum .. "]\n"
+        firstlinenum = "//firstlinenum[" .. firstlinenum .. "]\n"
         break
       end
     end
+  end
+
+  local caption = attr_val(attr, "caption") -- ```{caption=CAPTION}
+  local identifier = ""
+  local em = classes["em"] and "em" or ""
+  if (caption ~= "") then
+    list_num = list_num + 1
+    identifier = "[list" .. list_num .. "]"
+  else
+    em = "em"
   end
 
   return string.format(

--- a/review.lua
+++ b/review.lua
@@ -262,7 +262,7 @@ function CodeBlock(s, attr)
   not_lang["number-lines"] = true
   for key,_ in pairs(classes) do
     if not_lang[key] ~= true then
-      lang = key
+      lang = "[" .. key .. "]"
       break
     end
   end
@@ -287,14 +287,19 @@ function CodeBlock(s, attr)
   if (caption ~= "") then
     list_num = list_num + 1
     identifier = "[list" .. list_num .. "]"
+    caption = "[" .. caption .. "]"
   else
     em = "em"
+    if lang ~= "" then
+      caption = "[" .. caption .. "]"
+    end
   end
 
-  return string.format(
-    "%s//%slist%s%s[%s][%s]{\n%s\n//}",
-    firstlinenum, em, num, identifier, caption, lang, s
-  )
+  return (
+      firstlinenum ..
+      "//" .. em .. "list" .. num .. identifier .. caption .. lang ..
+      "{\n" .. s .. "\n//}"
+    )
 end
 
 function LineBlock(s)

--- a/review.lua
+++ b/review.lua
@@ -166,16 +166,22 @@ local function attr_val(attr, key)
   return ""
 end
 
+local function attr_classes(attr)
+  local classes = {}
+
+  for cls in attr_val(attr, "class"):gmatch("[^%s]+") do
+    classes[cls] = true
+  end
+  return classes
+end
+
 function Header(level, s, attr)
   local headmark = ""
   for i = 1, level do
     headmark = headmark .. "="
   end
 
-  local classes = {}
-  for cls in attr_val(attr, "class"):gmatch("[^%s]+") do
-    classes[cls] = true
-  end
+  local classes = attr_classes(attr)
 
   headmark = headmark .. (
     -- Re:view's behavior
@@ -250,21 +256,45 @@ function BlockQuote(s)
 end
 
 function CodeBlock(s, attr)
-  tag = "//"
-
-  caption = attr_val(attr, "caption") -- ```{caption=CAPTION}
+  local caption = attr_val(attr, "caption") -- ```{caption=CAPTION}
+  local identifier = ""
+  local em = ""
   if (caption ~= "") then
     list_num = list_num + 1
-    tag = tag .. "list[list" .. list_num .. "][" .. caption .. "]"
+    identifier = "[list" .. list_num .. "]"
   else
-    tag = tag .. "emlist"
+    em = "em"
   end
 
-  cls = attr_val(attr, "class")
-  if (cls ~= "") then
-    tag = tag .. "[][" .. cls .. "]"
+  local classes = attr_classes(attr)
+  local lang = ""
+  local not_lang = {numberLines = true, num = true}
+  not_lang["number-lines"] = true
+  for key,_ in pairs(classes) do
+    if not_lang[key] ~= true then
+      lang = key
+      break
+    end
   end
-  return tag .. "{\n" .. s .. "\n//}"
+
+  local num = (classes["numberLines"] or classes["number-lines"] or classes["num"]
+    ) and "num" or ""
+
+  local firstlinenum = ""
+  if num == "num" then
+    for _, key in ipairs({"startFrom", "start-from", "firstlinenum"}) do
+      firstlinenum = attr_val(attr, key)
+      if firstlinenum ~= "" then
+        tag = "//firstlinenum[" .. firstlinenum .. "]\n"
+        break
+      end
+    end
+  end
+
+  return string.format(
+    "%s//%slist%s%s[%s][%s]{\n%s\n//}",
+    firstlinenum, em, num, identifier, caption, lang, s
+  )
 end
 
 function LineBlock(s)


### PR DESCRIPTION
- 機能追加
   - `nuberLines`クラスなどによる行番号の付与
   - `startFrom` attributeなどによる開始番号の指定（`firstlinenum`相当）
   - `em`クラスによる明示的なembed
- codeBlockに複数のクラスが指定されている時も動作するよう変更
- #16におけるcaptioned CodeBlockの出力を修正

クラス名などは、PandocとRe:viewのドキュメントに倣ってます。

<details><summary>例</summary>

```bash
pandoc example.md -t review.lua -f markdown-auto_identifiers
```

## 入力

````
# no lang

```
foo
```

```{.numberLines}
foo
```

# lang

```{.ruby .numberLines}
foo
```

```{.ruby .numberLines startFrom=2}
foo
```

```{.ruby .numberLines startFrom=2 caption='caption'}
foo
```

## embed

```{.ruby .em .numberLines startFrom=2 caption='caption'}
foo
```
````

## 出力

````
= no lang

//emlist[][]{
foo
//}

//emlistnum[][]{
foo
//}

= lang

//emlistnum[][ruby]{
foo
//}

//firstlinenum[2]
//emlistnum[][ruby]{
foo
//}

//firstlinenum[2]
//listnum[list1][caption][ruby]{
foo
//}

== embed

//firstlinenum[2]
//emlistnum[list2][caption][ruby]{
foo
//}
````

</details>