### PR TITLE
support scaling images (closes #21)

### DIFF
--- a/review.lua
+++ b/review.lua
@@ -411,7 +411,7 @@ end
 function CaptionedImage(s, src, tit, attr)
   local path = "[" .. s:gsub("%.%w+$", ""):gsub("images/", "") .. "]"
 
-  local comment = src:gsub("fig:", ""):gsub("(.+)", "\n%1\n")
+  local comment = src:gsub("fig:", ""):gsub("(.+)", "\n%1")
 
   local scale = attr_scale(attr, "scale")
   if scale == "" then
@@ -439,7 +439,7 @@ function CaptionedImage(s, src, tit, attr)
   end
 
   return (
-    command .. path .. caption .. scale .. "{" .. comment .. "//}"
+    command .. path .. caption .. scale .. "{" .. comment .. "\n//}"
   )
 end
 

--- a/review.lua
+++ b/review.lua
@@ -411,7 +411,7 @@ end
 function CaptionedImage(s, src, tit, attr)
   local path = "[" .. s:gsub("%.%w+$", ""):gsub("^images/", "") .. "]"
 
-  local comment = src:gsub("fig:", ""):gsub("(.+)", "\n%1")
+  local comment = src:gsub("^fig:", ""):gsub("(.+)", "\n%1")
 
   local scale = attr_scale(attr, "scale")
   if scale == "" then

--- a/review.lua
+++ b/review.lua
@@ -404,12 +404,12 @@ end
 function Image(s, src, tit)
   -- Re:VIEW @<icon> ignores caption and title
   local id = string.gsub(src, "%.%w+$", "")
-  id = string.gsub(id, "images/", "")
+  id = string.gsub(id, "^images/", "")
   return format_inline("icon", id)
 end
 
 function CaptionedImage(s, src, tit, attr)
-  local path = "[" .. s:gsub("%.%w+$", ""):gsub("images/", "") .. "]"
+  local path = "[" .. s:gsub("%.%w+$", ""):gsub("^images/", "") .. "]"
 
   local comment = src:gsub("fig:", ""):gsub("(.+)", "\n%1")
 

--- a/review.lua
+++ b/review.lua
@@ -409,11 +409,9 @@ function Image(s, src, tit)
 end
 
 function CaptionedImage(s, src, tit, attr)
-  local id = s:gsub("%.%w+$", ""):gsub("images/", "")
+  local path = "[" .. s:gsub("%.%w+$", ""):gsub("images/", "") .. "]"
 
-  if (src ~= "" and src ~= "fig:") then
-    src = src:gsub("fig:", "")
-  end
+  local comment = src:gsub("fig:", ""):gsub("(.+)", "\n%1\n")
 
   local scale = attr_scale(attr, "scale")
   if scale == "" then
@@ -429,15 +427,19 @@ function CaptionedImage(s, src, tit, attr)
     end
   end
   if scale ~= "" then
-    scale = "[" .. scale .. "]"
+    scale = "[scale=" .. scale .. "]"
   end
 
-  if (tit ~= "") or (scale ~= "") then
-    tit = "[" .. tit .. "]"
+  local command = "//image"
+  local caption = ""
+  if (tit == "") then
+    command = "//indepimage"
+  else
+    caption = "[" .. tit .. "]"
   end
 
   return (
-    "//image[" .. id .. "]" .. tit .. scale .. "{\n" .. src .. "\n//}"
+    command .. path .. caption .. scale .. "{" .. comment .. "//}"
   )
 end
 

--- a/review.lua
+++ b/review.lua
@@ -175,6 +175,21 @@ local function attr_classes(attr)
   return classes
 end
 
+local function attr_scale(attr, key) -- a helper for CaptionedImage
+  scale = attr_val(attr, key)
+  if (scale == "") or (key == "scale") then
+    return scale
+  end
+
+  scale, count = scale:gsub("%%$", "")
+  if count == 0 then
+    log("WARNING: units must be % for width and height attributes of Image.\n")
+    return ""
+  end
+
+  return tonumber(scale) / 100
+end
+
 function Header(level, s, attr)
   local headmark = ""
   for i = 1, level do
@@ -393,21 +408,37 @@ function Image(s, src, tit)
   return format_inline("icon", id)
 end
 
-function CaptionedImage(s, src, tit)
-  local id = string.gsub(s, "%.%w+$", "")
-  id = string.gsub(id, "images/", "")
-  local buffer = {}
-  if (tit ~= "") then
-    table.insert(buffer, "//image[" .. id .. "][" .. tit .. "]{")
-  else
-    table.insert(buffer, "//indepimage[" .. id .. "]{")
-  end
+function CaptionedImage(s, src, tit, attr)
+  local id = s:gsub("%.%w+$", ""):gsub("images/", "")
+
   if (src ~= "" and src ~= "fig:") then
-    src = string.gsub(src, "fig:", "")
-    table.insert(buffer, src)
+    src = src:gsub("fig:", "")
   end
-  table.insert(buffer, "//}")
-  return table.concat(buffer, "\n")
+
+  local scale = attr_scale(attr, "scale")
+  if scale == "" then
+    local width = attr_scale(attr, "width")
+    local height = attr_scale(attr, "height")
+    if (width ~= "") then
+      if (height ~= "") and (width ~= height) then
+        log("WARNING: Image width and height must be same. Using width.\n")
+      end
+      scale = width
+    else
+      scale = height
+    end
+  end
+  if scale ~= "" then
+    scale = "[" .. scale .. "]"
+  end
+
+  if (tit ~= "") or (scale ~= "") then
+    tit = "[" .. tit .. "]"
+  end
+
+  return (
+    "//image[" .. id .. "]" .. tit .. scale .. "{\n" .. src .. "\n//}"
+  )
 end
 
 function Note(s)

--- a/review.lua
+++ b/review.lua
@@ -183,7 +183,7 @@ local function attr_scale(attr, key) -- a helper for CaptionedImage
 
   scale, count = scale:gsub("%%$", "")
   if count == 0 then
-    log("WARNING: units must be % for width and height attributes of Image.\n")
+    log("WARNING: Units must be % for `" .. key .. "` of Image. Ignored.\n")
     return ""
   end
 


### PR DESCRIPTION
画像のスケーリングに対応しました。
実装方針は #21 の通りです。

<details><summary>input</summary>

```
![](path.png)

![title](path.png)

![title](path.png){scale=0.5}

![title](path.png){width=50%}

![title](path.png){height=50%}

# warning

![title](path.png){width=30}

![title](path.png){width=30% height=50%}
```
</details>


<details><summary>output</summary>

WARNINGはわざと発生させたものです。

```
WARNING: Units must be % for `width` of Image. Ignored.
WARNING: Image width and height must be same. Using width.
//image[path]{

//}

//image[path][title]{
fig:
//}

//image[path][title][0.5]{
fig:
//}

//image[path][title][0.5]{
fig:
//}

//image[path][title][0.5]{
fig:
//}

= warning

//image[path][title]{
fig:
//}

//image[path][title][0.3]{
fig:
//}
```
</details>