### PR TITLE
handling raw as embed

### DIFF
--- a/pandoc2review-lib.rb
+++ b/pandoc2review-lib.rb
@@ -23,6 +23,10 @@ def main
       if @disableeaw
         args += ['-M', "softbreak:true"]
       end
+
+      if @hideraw
+        args += ['-M', "hideraw:true"]
+      end
     end
 
     if @heading
@@ -43,6 +47,7 @@ end
 def parse_args
   @heading = nil
   @disableeaw = nil
+  @hideraw = nil
   opts = OptionParser.new
   opts.banner = 'Usage: pandoc2review [option] file [file ...]'
   opts.version = '1.0'
@@ -56,6 +61,9 @@ def parse_args
   end
   opts.on('--disable-eaw', "Disable compositing a paragraph with Ruby's EAW library.") do
     @disableeaw = true
+  end
+  opts.on('--hideraw', "Hide raw inline/block with no review format specified.") do
+    @hideraw = true
   end
 
   opts.parse!(ARGV)

--- a/review.lua
+++ b/review.lua
@@ -542,10 +542,8 @@ function RawInline(format, text)
 
   if (format == "tex") then
     return format_inline("embed", "|latex|" .. text)
-  elseif (format == "html") then
-    return format_inline("embed", "|html|" .. text)
   else
-    return format_inline("embed", text)
+    return format_inline("embed", "|" .. format .. "|", text)
   end
 end
 

--- a/review.lua
+++ b/review.lua
@@ -532,11 +532,39 @@ function Span(s, attr)
 end
 
 function RawInline(format, text)
-  return text
+  if (format == "review") then
+    return text
+  end
+
+  if (metadata.hideraw) then
+    return ""
+  end
+
+  if (format == "tex") then
+    return format_inline("embed", "|latex|" .. text)
+  elseif (format == "html") then
+    return format_inline("embed", "|html|" .. text)
+  else
+    return format_inline("embed", text)
+  end
 end
 
 function RawBlock(format, text)
-  return text
+  if (format == "review") then
+    return text
+  end
+
+  if (metadata.hideraw) then
+    return ""
+  end
+
+  if (format == "tex") then
+    return "//embed[latex]{\n" .. text .. "\n//}"
+  elseif (format == "html") then
+    return "//embed[html]{\n" .. text .. "\n//}"
+  else
+    return "//embed{\n" .. text .. "\n//}"
+  end
 end
 
 try_catch {

--- a/review.lua
+++ b/review.lua
@@ -558,10 +558,8 @@ function RawBlock(format, text)
 
   if (format == "tex") then
     return "//embed[latex]{\n" .. text .. "\n//}"
-  elseif (format == "html") then
-    return "//embed[html]{\n" .. text .. "\n//}"
   else
-    return "//embed{\n" .. text .. "\n//}"
+    return "//embed[" .. format .. "]{\n" .. text .. "\n//}"
   end
 end
 

--- a/test/test_reviewlua.rb
+++ b/test/test_reviewlua.rb
@@ -742,6 +742,140 @@ EOB
     assert_equal expected, pandoc(src)
   end
 
+  def test_raw
+    src = <<-EOB
+<table>
+<thead><tr><th colspan="2">TABLEHEAD</th></tr></thead>
+<tbody><tr><td>Cell1</td><td>Cell2</td></tbody>
+</table>
+EOB
+
+    expected = <<-EOB
+//embed[html]{
+<table>
+//}
+
+//embed[html]{
+<thead>
+//}
+
+//embed[html]{
+<tr>
+//}
+
+//embed[html]{
+<th colspan="2">
+//}
+
+TABLEHEAD
+
+//embed[html]{
+</th>
+//}
+
+//embed[html]{
+</tr>
+//}
+
+//embed[html]{
+</thead>
+//}
+
+//embed[html]{
+<tbody>
+//}
+
+//embed[html]{
+<tr>
+//}
+
+//embed[html]{
+<td>
+//}
+
+Cell1
+
+//embed[html]{
+</td>
+//}
+
+//embed[html]{
+<td>
+//}
+
+Cell2
+
+//embed[html]{
+</td>
+//}
+
+//embed[html]{
+</tbody>
+//}
+
+//embed[html]{
+</table>
+//}
+EOB
+    # Bit ugly...
+    assert_equal expected, pandoc(src)
+
+    expected = <<-EOB
+
+
+
+
+
+
+
+
+TABLEHEAD
+
+
+
+
+
+
+
+
+
+
+
+
+
+Cell1
+
+
+
+
+
+Cell2
+
+
+
+
+
+EOB
+    # bit ugly...
+    assert_equal expected, pandoc(src, opts: '-M hideraw')
+
+    src = <<-EOB
+$$ \\alpha = \\beta\\label{eqone}$$
+Refer equation (\\ref{eqone}).
+EOB
+
+    expected = <<-EOB
+@<m>$\\displaystyle{} \\alpha = \\beta\\label{eqone}$ Refer equation (@<embed>$|latex|\\ref{eqone}$).
+EOB
+
+    assert_equal expected, pandoc(src)
+
+    expected = <<-EOB
+@<m>$\\displaystyle{} \\alpha = \\beta\\label{eqone}$ Refer equation ().
+EOB
+    assert_equal expected, pandoc(src, opts: '-M hideraw')
+  end
+
   def test_table
     src = <<-EOB
   Right     Left     Center     Default


### PR DESCRIPTION
RawBlock, RawInline でformatを見てembed化するようにしてみました。

- review形式なら(ってどう指定するんだろうというのはあるが)そのまま
- texならlatex付きembed
- htmlならhtml付きembed
- ほかよくわからなければ何も付けないembed

pandoc2reviewでは`--hide-raw`、pandocでは`-Mhideraw:true`でembed部分を出力しないようにしました。(ただ、Blockで空行は入ってしまいますが)