### PR TITLE
remove empty line from captioned block by Ruby implementation.

### DIFF
--- a/filters.lua
+++ b/filters.lua
@@ -107,9 +107,9 @@ local function caption_div(div)
   if div.attributes.caption then
     local begin = pandoc.Para(markdown(div.attributes.caption))
     table.insert(begin.content, 1, review_inline("//" .. class .. "["))
-    table.insert(begin.content, review_inline("]{"))
+    table.insert(begin.content, review_inline("]{<P2RREMOVEBELOW/>"))
     table.insert(div.content, 1, begin)
-    table.insert(div.content, pandoc.RawBlock("review", "//}"))
+    table.insert(div.content, pandoc.RawBlock("review", "<P2RREMOVEABOVE/>//}"))
     return div.content
   end
 end

--- a/pandoc2review-lib.rb
+++ b/pandoc2review-lib.rb
@@ -40,7 +40,7 @@ def main
       STDERR.puts stderr
       exit 1
     end
-    print softbreak(stdout)
+    print modify_result(stdout)
   end
 end
 
@@ -73,8 +73,10 @@ def parse_args
   end
 end
 
-def softbreak(s)
-  s.gsub('<P2RBR/>') do
+def modify_result(s)
+  s.gsub("<P2RREMOVEBELOW/>\n", '').
+    gsub("\n<P2RREMOVEABOVE/>", '').
+    gsub('<P2RBR/>') do
     tail = $`[-1]
     head = $'[0]
     return '' if tail.nil? || head.nil?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,9 +9,9 @@ def pandoc(src, opts: nil, err: nil)
   end
   if err
     stdout, stderr, status = Open3.capture3(args, stdin_data: src)
-    return softbreak(stdout), stderr
+    return modify_result(stdout), stderr
   else
     stdout, status = Open3.capture2(args, stdin_data: src)
-    softbreak(stdout)
+    modify_result(stdout)
   end
 end

--- a/test/test_reviewlua.rb
+++ b/test/test_reviewlua.rb
@@ -1018,11 +1018,9 @@ EOB
 
       expected = <<-EOB
 //#{tag}[foo]{
-
 Para1
 
 Para2
-
 //}
 EOB
 
@@ -1053,11 +1051,9 @@ EOB
 
       expected = <<-EOB
 //#{tag}[@<b>{foo} "]{
-
 Para1
 
 Para2
-
 //}
 EOB
 


### PR DESCRIPTION
`//note[caption]`などのキャプション付きブロックでブロック内前後空行を取るための一案(reファイルをマスターデータとしていじるというシーンだと、空行はないほうが気分的に良い)。

#41 で @atusy さんがLuaでやってみる方法というのをご検討されているのでこのマージはその結果次第で。
