### PR TITLE
Link as footnote

### DIFF
--- a/lua/review.lua
+++ b/lua/review.lua
@@ -357,7 +357,7 @@ function Link(s, src, tit)
   if (src == s) then
     return format_inline("href", src)
   else
-    return format_inline("href", src .. "," .. s)
+    return format_inline("href", src .. "," .. s) .. Note(src)
   end
 end
 

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -357,6 +357,7 @@ function Link(s, src, tit)
   if (src == s) then
     return format_inline("href", src)
   else
+    -- TODO: consider srcs without prefix `https?:`
     return format_inline("href", src .. "," .. s) .. Note(src)
   end
 end


### PR DESCRIPTION
## WHY

In a build flow as described below, the URL information in links in markdown will be lost in printed books.
```
markdown -(pandoc2review)-> re:view -> print
```
e.g. the text `https://example.com` in `[foo](https://example.com)` will never be printed in the book in any form.

## WHAT

Add footnotes when the src and str are not identical.
I'm not sure this is a good change for many users because this is apparently a breaking change and even if I made this an option, this logic doesn't work great with documents that contain links to labels.
see: https://github.com/kmuto/review/blob/master/doc/format.ja.md#%E3%83%AA%E3%83%B3%E3%82%AF
This is why this is just an experimental PR.