### PR TITLE
Pandoc3対応

### DIFF
--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -5,14 +5,19 @@ jobs:
   Pandoc:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.7', '3.1']
+        pandoc: ['2.11.3', '3.1.4']
     steps:
     - uses: actions/checkout@master
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: ${{ matrix.ruby }}
     - uses: r-lib/actions/setup-pandoc@v1
       with:
-        pandoc-version: '2.11.3'
+        pandoc-version: ${{ matrix.pandoc }}
     - run: |
         gem install bundler --no-document
         bundle install --retry 3

--- a/lib/pandoc2review.rb
+++ b/lib/pandoc2review.rb
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2020-2021 Kenshi Muto
+# Copyright 2020-2023 Kenshi Muto
 require 'optparse'
 require 'unicode/eaw'
 require 'pathname'
@@ -55,7 +55,7 @@ class Pandoc2ReVIEW
     @stripemptydev = nil
     opts = OptionParser.new
     opts.banner = 'Usage: pandoc2review [option] file [file ...]'
-    opts.version = '1.4'
+    opts.version = '1.5'
 
     opts.on('--help', 'Prints this message and quit.') do
       puts opts.help
@@ -74,7 +74,13 @@ class Pandoc2ReVIEW
       @stripemptydev = true
     end
 
-    opts.parse!(ARGV)
+    begin
+      opts.parse!(ARGV)
+    rescue OptionParser::ParseError
+      puts opts.help
+      exit 1
+    end
+
     if ARGV.size != 1
       puts opts.help
       exit 0

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -1,6 +1,6 @@
 -- -*- coding: utf-8 -*-
 -- Re:VIEW Writer for Pandoc
--- Copyright 2020 Kenshi Muto
+-- Copyright 2020-2023 Kenshi Muto
 
 -- config
 local config = {

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -24,7 +24,7 @@ local note_num = 0
 local footnotes = {}
 
 -- internal
-local metadata = nil
+local metadata = {}
 local stringify = (require "pandoc.utils").stringify
 local inline_commands = {
   -- processed if given as classes of Span elements
@@ -598,7 +598,9 @@ end
 
 try_catch {
   try = function()
-    metadata = PANDOC_DOCUMENT.meta
+    if PANDOC_VERSION < '3.0' then
+      metadata = PANDOC_DOCUMENT.meta
+    end
   end,
   catch = function(error)
     log("Due to your pandoc version is too old, config.yml loader is disabled.\n")

--- a/pandoc2review.gemspec
+++ b/pandoc2review.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "pandoc2review"
-  spec.version       = "1.4.0"
+  spec.version       = "1.5.0"
   spec.authors       = ["Kenshi Muto"]
   spec.email         = ["kmuto@kmuto.jp"]
   spec.license       = "GPL-2.0"


### PR DESCRIPTION
- PANDOC_DOCUMENT.metaがnilになった。YAML読み込みはRuby wrapperでは使わないのでここはがんばらないことにした
- metadataがnilのままだとエラーになるので、ハッシュにした
- OptionParserのパースエラーを捕捉していなかったので対処
- バージョン1.5でリリースする
