### PR TITLE
Support pandoc 3.0

### DIFF
--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -5,14 +5,19 @@ jobs:
   Pandoc:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['2.7', '3.1']
+        pandoc: ['2.11.3', '3.1.4']
     steps:
     - uses: actions/checkout@master
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: ${{ matrix.ruby }}
     - uses: r-lib/actions/setup-pandoc@v1
       with:
-        pandoc-version: '2.11.3'
+        pandoc-version: ${{ matrix.pandoc }}
     - run: |
         gem install bundler --no-document
         bundle install --retry 3

--- a/lua/filters.lua
+++ b/lua/filters.lua
@@ -154,6 +154,34 @@ local function noindent(para)
   return para
 end
 
+local function figure(fig)
+  -- Pandoc 3.x adds pandoc.Figure
+  if #fig.content > 1 or #fig.content[1].content > 1 then
+    error("NotImplemented")
+  end
+
+  local base = fig.content[1].content[1]
+
+  local attr = {}
+  for k, v in pairs(base.attributes) do
+    attr[k] = v
+  end
+  local classes = {}
+  for _, v in pairs(base.classes) do
+    table.insert(classes, "." .. v)
+  end
+  attr.classes = table.concat(classes, " ")
+  attr.identifier = base.attr.identifier
+  attr.is_figure = "true"
+
+  return pandoc.Image(
+    base.title,
+    base.src,
+    pandoc.utils.stringify(fig.caption),
+    attr
+  )
+end
+
 return {
   {Emph = support_strong("Strong")},
   {Strong = support_strong("Emph")},
@@ -164,5 +192,6 @@ return {
   {BulletList = nestablelist},
   {OrderedList = nestablelist},
   {DefinitionList = nestablelist},
-  {Div = caption_div}
+  {Div = caption_div},
+  {Figure = figure},
 }

--- a/lua/filters.lua
+++ b/lua/filters.lua
@@ -6,7 +6,11 @@ local beginchild = {pandoc.Plain(review_inline("//beginchild"))}
 local endchild = {pandoc.Plain(review_inline("//endchild"))}
 
 local function markdown(text)
-  return(pandoc.read(text, "markdown").blocks[1].content)
+  return pandoc.read(
+    text,
+    "markdown-auto_identifiers-smart+east_asian_line_breaks",
+    PANDOC_READER_OPTIONS
+  ).blocks[1].content
 end
 
 local function support_blankline(constructor)

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -477,6 +477,16 @@ function CaptionedImage(s, src, tit, attr)
   )
 end
 
+function Image(s, src, tit, attr)
+  -- Re:VIEW @<icon> ignores caption and title
+  if attr.is_figure then
+    return CaptionedImage(src, s, tit, attr)
+  end
+  local id = string.gsub(src, "%.%w+$", "")
+  id = string.gsub(id, "^images/", "")
+  return format_inline("icon", id)
+end
+
 function Note(s)
   note_num = note_num + 1
   table.insert(footnotes, "//footnote[fn" .. note_num .. "][" .. s .. "]")


### PR DESCRIPTION
- #58 と異なり、とりあえずは `classic_writer` で当座を凌ぐことにする
- `pandoc.read`が`pandoc`コマンドに与えたオプションに確実に従うようにした (Pandoc 3.x系ではデフォで無視する模様)
- `pandoc.Figure`に暫定対応するため、`pandoc.Image`に変換するフィルタと`CaptionedImage`ライターに投げる処理を加えた