### PR TITLE
LSPのDiagnostics関連の修正とリファクタリング

### DIFF
--- a/lua/filters.lua
+++ b/lua/filters.lua
@@ -142,7 +142,7 @@ local function caption_div(div)
 end
 
 local function noindent(para)
-  first = para.content[1]
+  local first = para.content[1]
 
   if (first and (first.tag == "RawInline") and
       (first.format == "tex") and

--- a/lua/filters.lua
+++ b/lua/filters.lua
@@ -29,7 +29,7 @@ local function support_blankline(constructor)
     local n_break = 0
     local content = blocks[i].content
 
-    for j, elem in ipairs(x.content) do
+    for _, elem in ipairs(x.content) do
       if elem.tag == "LineBreak" then
         -- Count the repeated number of LineBreak
         n_break = n_break + 1

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -180,7 +180,7 @@ local function attr_classes(attr)
 end
 
 local function attr_scale(attr, key) -- a helper for CaptionedImage
-  scale = attr_val(attr, key)
+  local scale, count = attr_val(attr, key), 0
   if (scale == "") or (key == "scale") then
     return scale
   end
@@ -288,7 +288,7 @@ function CodeBlock(s, attr)
   end
   command = command or "list"
 
-  is_list = command == "list"
+  local is_list = command == "list"
 
 
   local num = (is_list == false) and "" or (
@@ -411,7 +411,7 @@ function Table(caption, aligns, widths, headers, rows)
   end
   local tmp = {}
   for i, h in pairs(headers) do
-    align = html_align(aligns[i])
+    local align = html_align(aligns[i])
     if (config.use_table_align == "true") and (align ~= "") then
       h = format_inline("dtp", "table align=" .. align) .. h
     end
@@ -422,7 +422,7 @@ function Table(caption, aligns, widths, headers, rows)
   for _, row in pairs(rows) do
     tmp = {}
       for i, c in pairs(row) do
-      align = html_align(aligns[i])
+      local align = html_align(aligns[i])
       if (config.use_table_align == "true") and (align ~= "") then
         c = format_inline("dtp", "table align=" .. align) .. c
       end

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -161,13 +161,7 @@ function Para(s)
 end
 
 local function attr_val(attr, key)
-  local attr_table = {}
-  for k, v in pairs(attr) do
-    if (k == key and v and v ~= "") then
-      return v
-    end
-  end
-  return ""
+  return attr[key] or ""
 end
 
 local function attr_classes(attr)

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -586,7 +586,7 @@ function RawInline(format, text)
   if (format == "tex") then
     return format_inline("embed", "|latex|" .. text)
   else
-    return format_inline("embed", "|" .. format .. "|", text)
+    return format_inline("embed", "|" .. format .. "|" .. text)
   end
 end
 

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -189,10 +189,7 @@ local function attr_scale(attr, key) -- a helper for CaptionedImage
 end
 
 function Header(level, s, attr)
-  local headmark = ""
-  for i = 1, level do
-    headmark = headmark .. "="
-  end
+  local headmark = string.rep("=", level)
 
   local classes = attr_classes(attr)
 

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -1,6 +1,6 @@
 -- -*- coding: utf-8 -*-
 -- Re:VIEW Writer for Pandoc
--- Copyright 2020 Kenshi Muto
+-- Copyright 2020-2023 atusy and Kenshi Muto
 
 -- config
 local config = {

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -1,6 +1,6 @@
 -- -*- coding: utf-8 -*-
 -- Re:VIEW Writer for Pandoc
--- Copyright 2020-2023 atusy and Kenshi Muto
+-- Copyright 2020 Kenshi Muto
 
 -- config
 local config = {
@@ -514,7 +514,7 @@ function Div(s, attr)
   local blankline = attr_val(attr, "blankline")
   if blankline ~= "" then
     local buffer = {}
-    for i = 1, tonumber(blankline) do
+    for _ = 1, tonumber(blankline) do
       table.insert(buffer, "//blankline")
     end
     return table.concat(buffer, "\n")
@@ -609,7 +609,7 @@ local function configure()
 
   if (metadata) then
     -- Load config from YAML
-    for k,v in pairs(config) do
+    for k, _ in pairs(config) do
       if metadata[k] ~= nil then
         config[k] = stringify(metadata[k])
       end

--- a/test/test_reviewlua.rb
+++ b/test/test_reviewlua.rb
@@ -89,6 +89,10 @@ EOB
     assert_equal '@<tt>{a\*}', pandoc(src).chomp
     src = '`<$>`{.haskell}'
     assert_equal '@<tt>{<$>}', pandoc(src).chomp # XXX: ignore attribute
+    src = '`content`{=tex}'
+    assert_equal '@<embed>{|latex|content}', pandoc(src).chomp
+    src = '`content`{=latex}'
+    assert_equal '@<embed>{|latex|content}', pandoc(src).chomp
     src = '~~a~~'
     assert_equal '@<del>{a}', pandoc(src).chomp
     src = '[Small]{.smallcaps}'


### PR DESCRIPTION
- 重要なのは 5436fd6b4a623c57bcd1d530ad1d56f018e62ef8 でRawInlineが正しく出力されないバグを修正
- 他で無用なグローバル変数の除去や無用に複雑な関数のリファクタなどをしました