### PR TITLE
Pandoc 3への対応強化

### DIFF
--- a/lib/pandoc2review.rb
+++ b/lib/pandoc2review.rb
@@ -33,6 +33,10 @@ class Pandoc2ReVIEW
         args += ['-M', "stripemptydev:true"]
       end
 
+      if @classicwriter
+        args += ['-M', "classicwriter:true"]
+      end
+
       if @heading
         args += ["--shift-heading-level-by=#{@heading}"]
       end
@@ -53,6 +57,7 @@ class Pandoc2ReVIEW
     @disableeaw = nil
     @hideraw = nil
     @stripemptydev = nil
+    @classicwriter = nil
     opts = OptionParser.new
     opts.banner = 'Usage: pandoc2review [option] file [file ...]'
     opts.version = '1.6'
@@ -72,6 +77,9 @@ class Pandoc2ReVIEW
     end
     opts.on('--strip-emptydev', "Strip <div> without any id or class") do
       @stripemptydev = true
+    end
+    opts.on('--classic-writer', "Prefer classic custom writer on Pandoc 3.x to be compatible with Pandoc 2.x") do
+      @classicwriter = true
     end
 
     begin

--- a/lua/filters.lua
+++ b/lua/filters.lua
@@ -148,29 +148,6 @@ local function noindent(para)
   return para
 end
 
-local function figure(fig)
-  -- Pandoc 3.x adds pandoc.Figure
-  if #fig.content > 1 or #fig.content[1].content > 1 then
-    error("NotImplemented")
-  end
-
-  local base = fig.content[1].content[1]
-
-  local attr = {}
-  for k, v in pairs(base.attributes) do
-    attr[k] = v
-  end
-  local classes = {}
-  for _, v in pairs(base.classes) do
-    table.insert(classes, "." .. v)
-  end
-  attr.classes = table.concat(classes, " ")
-  attr.identifier = base.attr.identifier
-  attr.is_figure = "true"
-
-  return pandoc.Image(base.title, base.src, pandoc.utils.stringify(fig.caption), attr)
-end
-
 return {
   { Emph = support_strong("Strong") },
   { Strong = support_strong("Emph") },
@@ -182,5 +159,4 @@ return {
   { OrderedList = nestablelist },
   { DefinitionList = nestablelist },
   { Div = caption_div },
-  { Figure = figure },
 }

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -205,11 +205,7 @@ function Header(level, s, attr)
 end
 
 function HorizontalRule()
-  if config.use_hr == "true" then
-    return "//hr"
-  else
-    return ""
-  end
+  return config.use_hr == "true" and "//hr" or ""
 end
 
 local function lint_list(s)

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -452,12 +452,7 @@ function Cite(s, cs)
 end
 
 function Quoted(quotetype, s)
-  if quotetype == "SingleQuote" then
-    return SingleQuoted(s)
-  end
-  if quotetype == "DoubleQuote" then
-    return DoubleQuoted(s)
-  end
+  return _G[quotetype](s)
 end
 
 function SingleQuoted(s)

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -468,13 +468,9 @@ function SmallCaps(s)
 end
 
 function Div(s, attr)
-  local blankline = attr_val(attr, "blankline")
-  if blankline ~= "" then
-    local buffer = {}
-    for _ = 1, tonumber(blankline) do
-      table.insert(buffer, "//blankline")
-    end
-    return table.concat(buffer, "\n")
+  local blankline = tonumber(attr.blankline)
+  if blankline then
+    return string.rep("//blankline\n", blankline):gsub("\n$", "")
   end
 
   local classes = attr_classes(attr)

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -103,15 +103,7 @@ local function format_inline(fmt, s)
 end
 
 local function html_align(align)
-  if align == "AlignLeft" then
-    return ""
-  elseif align == "AlignRight" then
-    return "right"
-  elseif align == "AlignCenter" then
-    return "center"
-  else
-    return ""
-  end
+  return ({ AlignRight = "right", AlignCenter = "center" })[align] or ""
 end
 
 function Blocksep()

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -752,6 +752,13 @@ function Writer(doc, opts)
   PANDOC_WRITER_OPTIONS = opts
   configure()
 
+  if metadata.classicwriter then
+    if pandoc.write_classic then
+      return pandoc.write_classic(doc, opts)
+    end
+    log("WARNING: pandoc.write_classic is defunct. Using modern writer")
+  end
+
   -- body should keep trailing new lines but remove one if there are footnotes for the backward-compatibility
   local body = pandoc.layout.render(pandoc.layout.concat({ blocks(doc.blocks, "\n") }))
   return Doc(#footnotes == 0 and body or body:gsub("\n$", ""))

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -118,16 +118,11 @@ function Blocksep()
   return "\n\n"
 end
 
-function Doc(body, metadata, variables)
-  local buffer = {}
-  local function add(s)
-    table.insert(buffer, s)
+function Doc(body, meta, variables)
+  if #footnotes == 0 then
+    return body
   end
-  add(body)
-  if #footnotes > 0 then
-    add("\n" .. table.concat(footnotes, "\n"))
-  end
-  return table.concat(buffer, "\n")
+  return table.concat({ body, "", table.concat(footnotes, "\n") }, "\n")
 end
 
 function Str(s)

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -441,8 +441,7 @@ function Image(s, src, tit, attr)
   if attr.is_figure then
     return CaptionedImage(src, s, tit, attr)
   end
-  local id = string.gsub(src, "%.%w+$", "")
-  id = string.gsub(id, "^images/", "")
+  local id = src:gsub("%.%w+$", ""):gsub("^images/", "")
   return format_inline("icon", id)
 end
 

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -138,11 +138,7 @@ function LineBreak()
 end
 
 function SoftBreak(s)
-  if metadata.softbreak then
-    return " "
-  else
-    return "<P2RBR/>"
-  end
+  return metadata.softbreak and " " or "<P2RBR/>"
 end
 
 function Plain(s)

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -425,13 +425,8 @@ function CaptionedImage(s, src, tit, attr)
     scale = "[scale=" .. scale .. "]"
   end
 
-  local command = "//image"
-  local caption = ""
-  if tit == "" then
-    command = "//indepimage"
-  else
-    caption = "[" .. tit .. "]"
-  end
+  local command = tit == "" and "//indepimage" or "//image"
+  local caption = tit == "" and "" or ("[" .. tit .. "]")
 
   return (command .. path .. caption .. scale .. "{" .. comment .. "\n//}")
 end

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -257,26 +257,23 @@ end
 function CodeBlock(s, attr)
   local classes = attr_classes(attr)
 
-  local command = nil
+  local command = "list" -- default
   for k, v in pairs({ cmd = "cmd", source = "source", quote = "source" }) do
     if classes[k] then
       command = v
       break
     end
   end
-  command = command or "list"
 
   local is_list = command == "list"
 
-  local num = (is_list == false) and ""
-    or ((classes["numberLines"] or classes["number-lines"] or classes["num"]) and "num" or "")
+  local num = (is_list and (classes["numberLines"] or classes["number-lines"] or classes["num"])) and "num" or ""
 
   local firstlinenum = ""
   if is_list and (num == "num") then
     for _, key in ipairs({ "startFrom", "start-from", "firstlinenum" }) do
-      firstlinenum = attr_val(attr, key)
-      if firstlinenum ~= "" then
-        firstlinenum = "//firstlinenum[" .. firstlinenum .. "]\n"
+      if attr[key] then
+        firstlinenum = "//firstlinenum[" .. attr[key] .. "]\n"
         break
       end
     end

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -83,21 +83,19 @@ local function log(s)
 end
 
 local function surround_inline(s)
-  if string.match(s, "{") or string.match(s, "}") then
-    if string.match(s, "%$") then -- use % for regexp escape
-      if string.match(s, "|") then
-        -- give up. escape } by \}
-        return "{" .. string.gsub(s, "}", "\\}") .. "}"
-      else
-        -- surround by ||
-        return "|" .. s .. "|"
-      end
-    else
-      -- surround by $$
-      return "$" .. s .. "$"
-    end
+  if not s:match("[{}]") then
+    return "{" .. s .. "}"
   end
-  return "{" .. s .. "}"
+  if not s:match("%$") then
+    return "$" .. s .. "$"
+  end
+
+  -- use % for regexp escape
+  if s:match("|") then
+    -- give up. escape } by \}
+    return "{" .. s:gsub("}", "\\}") .. "}"
+  end
+  return "|" .. s .. "|"
 end
 
 local function format_inline(fmt, s)

--- a/lua/review.lua
+++ b/lua/review.lua
@@ -558,15 +558,14 @@ local function configure()
   end
 end
 
-local meta = {}
-meta.__index = function(_, key)
-  log(string.format("WARNING: Undefined function '%s'\n", key))
-  return function()
-    return ""
-  end
-end
-
-setmetatable(_G, meta)
+setmetatable(_G, {
+  __index = function(_, key)
+    log(string.format("WARNING: Undefined function '%s'\n", key))
+    return function()
+      return ""
+    end
+  end,
+})
 
 if PANDOC_VERSION < "3.0.0" then
   configure()


### PR DESCRIPTION
* 既存のライタのリファクタ。ちょっとでも行数減らしたくなったので…… (最終的に779行のライタになる)
    * e50020e832a9981d64b6b13c1fec2b36627fa97d から 10c4dbbf9ba9ac209f1cf2aebe4744f9e4493898 まで
    * bd4ac83029e8ce7620b242d1dc7895244ed7fbdc
* `pandoc.write_classic`の卒業 a0b2c429aba02070d62842d05eff52c74f3801b1ab41881f666630bba6a357dabe944abe55912a99
* 必要に応じて`pandoc.write_classic`を使えるよう `--classic-writer` オプションを追加
    * 174ef5617f57b5bd6c4681b16de561bc44fe338c
    * 現状テストがないです
        * `assert_equal expected, pandoc(src, opts: '-M classicwriter')`をすればいいはずではあるものの、これを愚直に全箇所書くのもなあと思い……
* pandoc.Figureを出力する時にキャプションをstringifyしちゃってたのでちゃんとmarkdown -> reviewする機能を追加 ab41881f666630bba6a357dabe944abe55912a99

